### PR TITLE
replace non-standard character

### DIFF
--- a/R/rcode_analyzer.R
+++ b/R/rcode_analyzer.R
@@ -236,7 +236,7 @@ get_dplyr_intermediates <- function(pipeline) {
       msg <- ifelse(!grepl("Error:", msg), paste("<strong>Error:</strong>", msg), msg)
       # style back the x's, i's, and *
       msg <- gsub("\nx", "<br><span style='color:red'>x</span>", msg)
-      msg <- gsub("\nℹ", "<br><span style='color:DodgerBlue'>ℹ</span>", msg)
+      msg <- gsub("\n\u2139", "<br><span style='color:DodgerBlue'>\u2139</span>", msg)
       msg <- gsub("\n\\*", "<br>*", msg)
       intermediate[["err"]] <- msg
       # try to retain the format as much as possible by keeping it as HTML string


### PR DESCRIPTION
I was hitting an error whilst trying to install, and it was due to the non-standard character. The package installs now, however, I'm not sure whether this line will still function as you expect it to.  You may have to change the output of the `gsub()` from `"\u2139"` to `"<U+2139>"` or `"&x2139;"`.