### PR TITLE
Added an RStudio addin for easier entry into Unravel (fixes issue #70)

### DIFF
--- a/R/unravel.R
+++ b/R/unravel.R
@@ -61,6 +61,17 @@ unravel <- function(code = NULL, viewer = T) {
   )
 }
 
+#' The binding function for unraveling code using the add-in.
+#'
+#' @return A shiny app
+#' @export
+unravel_addin <- function() {
+  require(tidylog)
+  ec <- rstudioapi::getSourceEditorContext()
+  selected <- ec$selection[[1]]$text
+  unravel_code(code = selected)
+}
+
 #' A variant of `unravel` to support accepting the code character instead.
 #'
 #' @param code A character

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,14 +65,6 @@ clear_callouts <- function() {
   rm(list=ls(callout_cache, all.names=TRUE), envir=callout_cache)
 }
 
-# set tidylog messages to re-route to our tidylog_cache environment so we can access it
-require(tidylog)
-# this is done after all the utility functions for getting/setting summaries are defined above
-options(
-  "tidylog.display" = list(DataTutor:::store_verb_summary),
-  "tidylog.callouts" = DataTutor:::store_line_callouts
-)
-
 #' Returns an abbreviated version of a number (K for thousndas and M for millions)
 #'
 #' We won't do more than millions of rows for now.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,9 @@
+.onLoad <- function(libname, pkgname) {
+  # set tidylog messages to re-route to our tidylog_cache environment so we can access it
+  require(tidylog)
+  # this is done after all the utility functions for getting/setting summaries are defined above
+  options(
+    "tidylog.display" = list(DataTutor:::store_verb_summary),
+    "tidylog.callouts" = DataTutor:::store_line_callouts
+  )
+}

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,5 @@
+Name: Unravel code
+Description: Unravels tidyverse code at the cursor position
+Binding: unravel_addin
+Interactive: true
+


### PR DESCRIPTION
In addition to adding the addin for Unravel, we're also making sure the `{tidylog}` and its respective DataTutor-related options are set on library load time.