### PR TITLE
More graceful error handling

### DIFF
--- a/R/unravel.R
+++ b/R/unravel.R
@@ -1,6 +1,7 @@
 
 invoke_unravel <- function(code, viewer = T) {
-  require(shiny)
+  library(shiny)
+  suppressMessages(library(tidylog))
 
   ui <- fluidPage(
     unravelUI("unravel")
@@ -87,7 +88,6 @@ unravel_code <- function(code = "", viewer = T) {
 #' @return A shiny app
 #' @export
 unravel_addin <- function() {
-  require(tidylog)
   ec <- rstudioapi::getSourceEditorContext()
   selected <- ec$selection[[1]]$text
   invoke_unravel(code = selected)


### PR DESCRIPTION
This PR makes error handling more graceful by attempting to render all lines in Unravel and allowing users to toggle off problematic lines.

For example, consider the following snippet includes a `mean()` function which causes an error since a `data.frame` is not a `numeric` or `logical`:

![Screen Shot 2021-11-16 at 2 38 16 PM](https://user-images.githubusercontent.com/9612286/142053847-6a177ceb-57e5-4532-b88a-ffd64a76060b.png)

We simply point out that the step produced an NA, but the warning also appears on the console:

![Screen Shot 2021-11-16 at 2 42 00 PM](https://user-images.githubusercontent.com/9612286/142054424-7a025ec6-57dc-4e9c-a2b4-366e0021b5fc.png)

```
Warning in mean.default(.) :
  argument is not numeric or logical: returning NA
```

We will render all lines and user can disable `mean()`

![Screen Shot 2021-11-16 at 2 38 38 PM](https://user-images.githubusercontent.com/9612286/142053896-c4f88437-d15a-472f-8d9a-147582227cd9.png)



