### PR TITLE
Support basic outputs besides dataframes

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onLoad <- function(libname, pkgname) {
+  suppressMessages(library(tidylog))
   # set tidylog messages to re-route to our tidylog_cache environment so we can access it
-  require(tidylog)
   # this is done after all the utility functions for getting/setting summaries are defined above
   options(
     "tidylog.display" = list(DataTutor:::store_verb_summary),


### PR DESCRIPTION
This PR starts addressing issue #73. 

We added logic in the Shiny app for Unravel to display other types of data that can be printed via `shiny::renderPrint()` like vectors and lists. 

This means that we can now have tidyverse code that incorporates steps that have non-dataframe outputs. 

**Dataframe:** 

![Screen Shot 2021-11-18 at 11 36 21 AM](https://user-images.githubusercontent.com/9612286/142457320-d47fdaff-cda1-4af7-8e19-745a8801ab81.png)

**Non-Dataframe:**

![Screen Shot 2021-11-18 at 11 37 51 AM](https://user-images.githubusercontent.com/9612286/142457624-150c35c7-6404-487d-9281-fea4a5402b51.png)

