### PR TITLE
Fix evaluation to render all problematic lines

### DIFF
--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -660,7 +660,7 @@ unravelServer <- function(id, user_code = NULL) {
       # this is the output for non-dataframe and non-plot objects like vectors and lists
       output$generic_output <- renderUI({
         generic_output <- data()
-        if (!is.data.frame(generic_output)) {
+        if (!is.data.frame(generic_output) && !is.null(generic_output)) {
           shiny::tagList({
             shiny::renderPrint(generic_output)
           })


### PR DESCRIPTION
This PR addresses issue #79 and #66. 

If we have problematic lines such as the example below we point out (for now) that there is an issue with the previous lines:

<img width="712" alt="Screen Shot 2021-11-22 at 4 22 39 PM" src="https://user-images.githubusercontent.com/9612286/142937099-47aa49f6-5f13-4313-9ef8-daa52e8715d3.png">

Then, the user can trace back the issue to the culprit line which is `mean()` in this case:

<img width="751" alt="Screen Shot 2021-11-22 at 4 23 44 PM" src="https://user-images.githubusercontent.com/9612286/142937216-9c54edf3-79a8-4f75-bffb-4c2bc5b53693.png">

