### PR TITLE
Lock the first line, and prevent reorder of other lines before it

### DIFF
--- a/R/unravel_app.R
+++ b/R/unravel_app.R
@@ -205,35 +205,42 @@ group_item_div <- function(line, ns_id) {
   col <- line$col
   # whereas id is for a readable identifier for JS/jquery/CSS
   id <- paste0("line", line$lineid)
-  div(class = "d-flex list-group-item", id=id, `data-id` = line_id,
-      # row div
-      div(class = "justify-content-center align-self-baseline",
-          div(class = "d-flex justify-content-center align-self-center",
-              div(class = "row", style = "font-size:0.8em;",
-                  HTML("&nbsp;")
-              )
-          ),
-          div(class = glue::glue("{id}-summary-box-row d-flex empty-square justify-content-center"),
-              div(class=glue::glue("{id}-row-content align-self-center"), style="font-size: 0.8em;",
-                  # update element
-                  HTML(row)
-              )
-          )
-      ),
-      # column div + square div
-      div(class = "justify-content-center align-self-baseline",
-          div(class = glue::glue("{id}-summary-box-col d-flex justify-content-center align-self-center"),
-              div(class = glue::glue("{id}-col-content row"), style = "font-size:0.8em;",
-                  # update element
-                  HTML(col)
-              )
-          ),
-          # update element (class of square)
-          summary_button(ns_id, id, line_id, change_type)
-      ),
+  is_verb_line <- line_id != 1L
+  core_divs <- list(
+    # row div
+    div(class = "justify-content-center align-self-baseline",
+        div(class = "d-flex justify-content-center align-self-center",
+            div(class = "row", style = "font-size:0.8em;",
+                HTML("&nbsp;")
+            )
+        ),
+        div(class = glue::glue("{id}-summary-box-row d-flex empty-square justify-content-center"),
+            div(class=glue::glue("{id}-row-content align-self-center"), style="font-size: 0.8em;",
+                # update element
+                HTML(row)
+            )
+        )
+    ),
+    # column div + square div
+    div(class = "justify-content-center align-self-baseline",
+        div(class = glue::glue("{id}-summary-box-col d-flex justify-content-center align-self-center"),
+            div(class = glue::glue("{id}-col-content row"), style = "font-size:0.8em;",
+                # update element
+                HTML(col)
+            )
+        ),
+        # update element (class of square)
+        summary_button(ns_id, id, line_id, change_type)
+    )
+  )
+  disabled <- ifelse(is_verb_line, "", "static")
+  core_divs <- append(
+    core_divs,
+    list(
       # glyphicon
+      # add the move icon if it's not the first line, else make it transparent
       div(class=glue::glue("{id}-glyph d-flex justify-content-center align-self-center"),
-          span(class="glyphicon glyphicon-move", style="opacity:1;")
+          span(class=glue::glue("glyphicon glyphicon-move {disabled}"), style=glue::glue("opacity:{as.integer(is_verb_line)};"))
       ),
       # codemirror empty div above
       div(class="d-flex justify-content-center align-self-center", style="padding:0.5em;",
@@ -245,25 +252,38 @@ group_item_div <- function(line, ns_id) {
         class = "verb",
         id = id,
         lineid = line_id
-      ),
-      # toggle checkbox
-      div(style="opacity:1; padding-right:0.25em;",
-          div(class="d-flex justify-content-center align-self-center",
-              div(style="font-size: 0.8em;", HTML("&nbsp;"))
-          ),
-          # the value of `checked` is not meaningful, the existence of attribute turns on toggle by default
-          shiny::tags$label(
-            class = "switch",
-            shiny::tags$input(
-              type = "checkbox",
-              class = "slider",
-              `toggle-id` = id,
-              `line-id` = line_id,
-              `checked` = TRUE
-            ),
-            span(class="slider round")
-          )
       )
+    )
+  )
+
+  if (is_verb_line) {
+    core_divs <- append(
+      core_divs,
+      list(
+        # toggle checkbox
+        div(style="opacity:1; padding-right:0.25em;",
+            div(class="d-flex justify-content-center align-self-center",
+                div(style="font-size: 0.8em;", HTML("&nbsp;"))
+            ),
+            # the value of `checked` is not meaningful, the existence of attribute turns on toggle by default
+            shiny::tags$label(
+              class = "switch",
+              shiny::tags$input(
+                type = "checkbox",
+                class = "slider",
+                `toggle-id` = id,
+                `line-id` = line_id,
+                `checked` = TRUE
+              ),
+              span(class="slider round")
+            )
+        )
+      )
+    )
+  }
+  # if it's the data line (first line), disable it for SortableJS so we can't move it
+  div(class = glue::glue("d-flex list-group-item {disabled}"), id=id, `data-id` = line_id,
+    core_divs
   )
 }
 

--- a/inst/css/style.css
+++ b/inst/css/style.css
@@ -147,6 +147,16 @@ h2 {
   padding-right: 0em;
 }
 
+.glyphicon-move.static {
+  font-size: 1em;
+  color: #2c3745;
+  cursor: pointer;
+  margin-top: 0.5em;
+  padding-left: 0.5em;
+  padding-right: 0em;
+}
+
+
 .list-group {
   width: auto;
   display: flex;


### PR DESCRIPTION
This PR address issue #86, where Unravel allowed a user to move / toggle the first dataframe line. 

Effectively, this PR makes changes such that:
- the first line cannot be moved but can be clicked on to view the summary and the dataframe
- the other lines cannot be reordered before the first line, if the user attempts this the reorder does not take place