### PR TITLE
Some minor fixes for first line lock

### DIFF
--- a/R/rcode_analyzer.R
+++ b/R/rcode_analyzer.R
@@ -147,7 +147,7 @@ get_dplyr_intermediates <- function(pipeline) {
   if (!has_pipes) {
     err <- NULL
     tryCatch(
-      first_arg_data <- is.data.frame(eval(as.list(pipeline)[[2]])),
+      first_arg_data <<- is.data.frame(eval(pipeline)),
       error = function(e) {
         err <<- crayon::strip_style(e$message)
       }
@@ -175,7 +175,7 @@ get_dplyr_intermediates <- function(pipeline) {
         line = 1,
         code = rlang::expr_deparse(pipeline),
         change = "error",
-        output = list(),
+        output = NULL,
         row = "",
         col = "",
         summary = "<strong>Summary:</strong> Your code does not use functions that take in a dataframe."
@@ -258,8 +258,9 @@ get_dplyr_intermediates <- function(pipeline) {
           # wrap output as list so it can be stored properly
           intermediate["output"] <- list(cur_output)
           change_type <- get_data_change_type(verb_name, prev_output, cur_output)
-        } else if (first_arg_data) {
-          # for single verb code simply get the change type based on verb for now
+        }
+        # for single verb code simply get the change type based on verb for now
+        if (first_arg_data) {
           change_type <- get_change_type(verb_name)
         }
         # store the dimensions of dataframe
@@ -280,7 +281,7 @@ get_dplyr_intermediates <- function(pipeline) {
         intermediate["callouts"] <- list(get_line_callouts())
         # if we have a dataframe %>% verb() expression, the 'dataframe' summary is simply
         # the dataframe/tibble with dimensions reported (we could expand that if we want)
-        if (i == 1 && has_pipes) {
+        if (i == 1 && (has_pipes || first_arg_data)) {
           verb_summary <- tidylog::get_data_summary(intermediate["output"][[1]])
         }
         # store the final function summary

--- a/inst/css/style.css
+++ b/inst/css/style.css
@@ -177,15 +177,8 @@ h2 {
   cursor:pointer;
 }
 
-.list-group-item .disabled {
-  width: 80%;
-  height: 10px;
-  opacity: 0;
-  border: 1px solid #eee;
-  padding: 2px;
-  margin: 2px;
-  display: flex;
-  align-items: center;
+.list-group-item.static {
+  background-color: #eee;
 }
 
 #simpleList {


### PR DESCRIPTION
Previously, Unravel would interpret a single line expression like `data.frame(replicate(5, sample(0:1, 5, rep = TRUE)))` as invalid since `replicate()` is a call and we only checked for first argument being a `data.frame`. Now we just check if the single line when evaluated produces a `data.frame`